### PR TITLE
Make host_metadata cap more robust.

### DIFF
--- a/lib/vagrant-skytap/cap/host_metadata.rb
+++ b/lib/vagrant-skytap/cap/host_metadata.rb
@@ -22,22 +22,63 @@
 
 require "socket"
 require "net/http"
+require "log4r"
 
 module VagrantPlugins
   module Skytap
     module Cap
       module HostMetadata
+        METADATA_LINK_LOCAL_ADDRESS = '169.254.169.254'
+        OPEN_TIMEOUT = 2
+        READ_TIMEOUT = 5
 
-        # Attempt to retrieve information about the Vagrant host
-        # from the metadata service. If found, we're running in a
-        # Skytap VM.
+        # If Vagrant is running in a Skytap VM, returns metadata from which an
+        # [API::Vm] can be constructed. Otherwise returns nil.
+        #
+        # @param [Vagrant::Machine] machine The guest machine (ignored).
+        # @return [Hash] or [NilClass]
         def self.host_metadata(machine)
-          begin
-            http = Net::HTTP.new("gw", 80)
-            response = http.request(Net::HTTP::Get.new("/skytap"))
-            JSON.parse(response.body) if response.is_a?(Net::HTTPOK)
-          rescue SocketError, Net::HTTPNotFound => ex
+          logger = Log4r::Logger.new("vagrant_skytap::cap::host_metadata")
+
+          # There are two addresses to try for the metadata service. If using
+          # the default DNS, 'gw' will resolve to the endpoint address. If
+          # using custom DNS, be prepared to fall back to the hard-coded IP
+          # address.
+          ['gw', METADATA_LINK_LOCAL_ADDRESS].each do |host|
+            begin
+              http = Net::HTTP.new(host)
+              http.open_timeout = OPEN_TIMEOUT
+              http.read_timeout = READ_TIMEOUT
+
+              # Test for a working web server before actually hitting the
+              # metadata service. The response is expected to be 404.
+              http.request(Net::HTTP::Get.new("/"))
+
+              begin
+                response = http.request(Net::HTTP::Get.new("/skytap"))
+              rescue Timeout::Error => ex
+                raise Errors::MetadataServiceUnavailable
+              end
+
+              if response.is_a?(Net::HTTPServerError)
+                raise Errors::MetadataServiceUnavailable
+              elsif response.is_a?(Net::HTTPOK)
+                attrs = JSON.parse(response.body)
+                return attrs if attrs.key?('configuration_url')
+                logger.debug("The JSON retrieved was not VM metadata! Ignoring.")
+              end
+            rescue SocketError => ex
+              logger.debug("Could not resolve hostname '#{host}'.")
+            rescue Errno::ENETUNREACH => ex
+              logger.debug("No route exists for '#{host}'.")
+            rescue Timeout::Error => ex
+              logger.debug("Response timed out for '#{host}'.")
+            rescue JSON::ParserError
+              logger.debug("Response from '#{host}' was garbled.")
+            end
           end
+
+          nil
         end
       end
     end

--- a/lib/vagrant-skytap/errors.rb
+++ b/lib/vagrant-skytap/errors.rb
@@ -100,6 +100,10 @@ module VagrantPlugins
       class VmParentMismatch < VagrantSkytapError
         error_key(:vm_parent_mismatch)
       end
+
+      class MetadataServiceUnavailable < VagrantSkytapError
+        error_key(:metadata_service_unavailable)
+      end
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -121,6 +121,10 @@ en:
       feature_not_supported_for_host_os: |-
         The %{feature_name} feature is currently not supported for your host operating system.
 
+      metadata_service_unavailable: |-
+        You appear to be running Vagrant in a Skytap VM. There was an error retrieving
+        information about this VM. Please retry later.
+
     states:
       short_not_created: |-
         not created

--- a/spec/unit/cap/host_metadata_spec.rb
+++ b/spec/unit/cap/host_metadata_spec.rb
@@ -24,20 +24,99 @@ require File.expand_path("../../base", __FILE__)
 require "vagrant-skytap/cap/host_metadata"
 
 describe VagrantPlugins::Skytap::Cap::HostMetadata do
-  let(:machine) { double("machine") }
+  include_context "skytap"
+
+  let(:machine)   { double(:machine) }
+  let(:metadata)  { {"id" => 1, "configuration_url" => "foo"} }
+  let(:metadata1) { metadata }
+  let(:metadata2) { metadata }
+  let(:status)    { 200 }
+  let(:status1)   { status }
+  let(:status2)   { status }
 
   before do
-    stub_request(:get, %r{http://gw/skytap}).to_return(body: '', status: 404)
+    stub_request(:any, /.*/).to_return(body: "", status: 404)
+    stub_request(:get, "http://gw/skytap").to_return(body: JSON.dump(metadata1), status: status1)
+    stub_request(:get, "http://169.254.169.254/skytap").to_return(body: JSON.dump(metadata2), status: status2)
+  end
+
+  def assert_fallback_to_ip
+    expect(a_request(:get, "http://169.254.169.254/")).to have_been_made
+  end
+
+  def assert_no_fallback_to_ip
+    expect(a_request(:get, "http://169.254.169.254/")).not_to have_been_made
   end
 
   describe "host_metadata" do
-    it "returns nil if the metadata is not found" do
-      expect(described_class.host_metadata(machine)).to be nil
+    subject do
+      described_class.host_metadata(machine)
     end
 
-    it "returns the metadata if found" do
-      stub_request(:get, %r{http://gw/skytap}).to_return(body: '{"id": 1}', status: 200)
-      expect(described_class.host_metadata(machine)).to eq({"id" => 1})
+    context "when default DNS is in use" do
+      it "should get the metadata from gw" do
+        expect(subject).to eq metadata
+        assert_no_fallback_to_ip
+      end
+
+      context "when metadata service is down" do
+        before do
+          stub_request(:get, "http://gw/skytap").to_timeout
+        end
+        it "should raise an exception without retrying" do
+          expect{subject}.to raise_error(Errors::MetadataServiceUnavailable)
+          assert_no_fallback_to_ip
+        end
+      end
+
+      context "when metadata service returns an error" do
+        let(:status1) { 500 }
+        it "should raise an exception without retrying" do
+          expect{subject}.to raise_error(Errors::MetadataServiceUnavailable)
+          assert_no_fallback_to_ip
+        end
+      end
+    end
+
+    context "when custom DNS is in use" do
+      context "when gw resolves to some random web server" do
+        let(:metadata1) { 'hello' }
+        it "should fall back to the fixed IP address" do
+          expect(subject).to eq metadata
+          assert_fallback_to_ip
+        end
+      end
+
+      context "when gw times out" do
+        before do
+          stub_request(:get, "http://gw/").to_timeout
+        end
+        it "should fall back to the fixed IP address" do
+          expect(subject).to eq metadata
+          assert_fallback_to_ip
+        end
+      end
+
+      context "when gw cannot be resolved" do
+        before do
+          stub_request(:get, "http://gw/").to_raise(SocketError)
+        end
+        it "should fall back to the fixed IP address" do
+          expect(subject).to eq metadata
+          assert_fallback_to_ip
+        end
+
+        # Or maybe this isn't a Skytap VM.
+        context "when fixed IP address is unreachable" do
+          before do
+            stub_request(:get, "http://169.254.169.254/").to_raise(Errno::ENETUNREACH)
+          end
+          it "should return nil" do
+            expect(subject).to eq nil
+            assert_fallback_to_ip
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a user is not using the default DNS, 'gw' will probably not resolve to the metadata service endpoint. We should fall back to the link local address in this case. Also, we should show an error if the metadata service is down.