### PR TITLE
Add vagrant-spec config and support files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,7 @@ Gemfile.lock
 
 # Vagrant
 .vagrant
-Vagrantfile
-!example_box/Vagrantfile
+/Vagrantfile
 
 # RVM files for gemset/ruby setting
 .ruby-*

--- a/spec/acceptance/base.rb
+++ b/spec/acceptance/base.rb
@@ -1,0 +1,25 @@
+# Copyright (c) 2014-2016 Skytap, Inc.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+require "vagrant-spec/acceptance"
+require_relative "shared/context_skytap"
+

--- a/spec/acceptance/shared/context_skytap.rb
+++ b/spec/acceptance/shared/context_skytap.rb
@@ -1,0 +1,25 @@
+# Copyright (c) 2014-2016 Skytap, Inc.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+shared_context "provider-context/skytap" do
+
+end

--- a/spec/acceptance/skeletons/generic/Vagrantfile
+++ b/spec/acceptance/skeletons/generic/Vagrantfile
@@ -1,0 +1,3 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "skytap/ubuntu-1204-x64-us-west"
+end

--- a/vagrant-spec.config.rb
+++ b/vagrant-spec.config.rb
@@ -1,0 +1,10 @@
+require_relative "spec/acceptance/base"
+
+Vagrant::Spec::Acceptance.configure do |c|
+  c.component_paths << File.expand_path("../spec/acceptance", __FILE__)
+  c.skeleton_paths << File.expand_path("../spec/acceptance/skeletons", __FILE__)
+
+  c.provider "skytap",
+    box: File.expand_path("../skytap-test.box", __FILE__),
+    contexts: ["provider-context/skytap"]
+end


### PR DESCRIPTION
This is to allow running vagrant-spec acceptance tests against the Skytap provider.

The file skytap-test.box is not part of this PR since it contains a reference to a non-public VM.