### PR TITLE
Make network tunnel error messages more helpful.

### DIFF
--- a/lib/vagrant-skytap/connection/tunnel_choice.rb
+++ b/lib/vagrant-skytap/connection/tunnel_choice.rb
@@ -51,19 +51,16 @@ module VagrantPlugins
         def valid?
           @validation_error_message = nil
 
-          unless host_network.tunnelable?
-            @validation_error_message = I18n.t("vagrant_skytap.connections.tunnel.errors.host_network_not_tunnelable")
-            return false
-          end
-
-          unless host_network.nat_enabled?
-            @validation_error_message = I18n.t("vagrant_skytap.connections.tunnel.errors.host_network_nat_disabled")
+          unless host_network.tunnelable? && host_network.nat_enabled?
+            @validation_error_message = I18n.t("vagrant_skytap.connections.tunnel.errors.host_network_not_connectable")
             return false
           end
 
           unless guest_network.nat_enabled?
             if guest_network.subnet.overlaps?(host_network.subnet)
-              @validation_error_message = I18n.t("vagrant_skytap.connections.tunnel.errors.guest_network_overlaps")
+              @validation_error_message = I18n.t("vagrant_skytap.connections.tunnel.errors.guest_network_overlaps",
+                                                 guest_subnet: guest_network.subnet, host_subnet: host_network.subnet,
+                                                 environment_url: iface.vm.environment.url)
               return false
             end
           end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -184,14 +184,20 @@ en:
         verb_create_and_use: |-
           Create and use tunnel to host network
         errors:
-          host_network_not_tunnelable: |-
-            The host's network must be tunnelable.
-          host_network_nat_disabled: |-
-            The host's network must have NAT enabled.
+          host_network_not_connectable: |-
+            To connect to the guest machine using a network tunnel, the host
+            VM must be connected to a network which is visible to other
+            networks and has a NAT subnet. Please go to the network settings
+            page for this VM and make these changes, then run `vagrant up` to
+            try again. (Note: it may be necessary to power off this VM before
+            making these changes.)
           guest_network_overlaps: |-
-            The guest's network subnet overlaps with the host's network.
-            (This can be resolved by changing network subnets, or by
-            enabling NAT on the guest network.)
+            The host and guest networks could not be connected via a network
+            tunnel because the guest VM's network subnet (%{guest_subnet})
+            overlaps with the host network subnet (%{host_subnet}). Please
+            change the guest network's subnet, or enable NAT on the guest
+            network's subnet, then run `vagrant up` to try again.
+            The guest VM's environment URL is: %{environment_url}
 
     commands:
       publish_urls:


### PR DESCRIPTION
Since correcting network configuration issues requires a VM restart, consolidate some error messages so the user can avoid unnecessary restarts. Also, give the guest environment's URL for convenience.