### PR TITLE
Additional error handling for fetching Skytap VM metadata.

### DIFF
--- a/lib/vagrant-skytap/cap/host_metadata.rb
+++ b/lib/vagrant-skytap/cap/host_metadata.rb
@@ -71,6 +71,10 @@ module VagrantPlugins
               logger.debug("Could not resolve hostname '#{host}'.")
             rescue Errno::ENETUNREACH => ex
               logger.debug("No route exists for '#{host}'.")
+            rescue Errno::EHOSTDOWN => ex
+              logger.debug("The OS reported that '#{host}' is down.")
+            rescue Errno::ECONNREFUSED => ex
+              logger.debug("The connection was refused by '#{host}'.")
             rescue Timeout::Error => ex
               logger.debug("Response timed out for '#{host}'.")
             rescue JSON::ParserError


### PR DESCRIPTION
We handle ENETUNREACH when attempting to access the metadata service, which generally means Vagrant is not running in a Skytap VM. On MacOSX 10.10 (and possibly other OSes), in some cases it returns EHOSTDOWN instead. (In fact, traceroute may report either or both errors on subsequent retries.)